### PR TITLE
HVT-4955: Add connect command flag validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,7 +18,7 @@ const (
 	defaultDirectory     = ".config/hcp/hvd"
 	testDirectory        = "hcptest"
 	fileName             = "hvd_proxy_config.json"
-	directoryPermissions = 0755
+	directoryPermissions = 0o755
 
 	envVarCacheTestMode = "HCP_CACHE_TEST_MODE"
 )

--- a/config_test.go
+++ b/config_test.go
@@ -37,7 +37,6 @@ func Test_GetHCPConfiguration(t *testing.T) {
 				assert.Nil(t, tk)
 				assert.Nil(t, err)
 			}
-
 		})
 	}
 }

--- a/connect.go
+++ b/connect.go
@@ -104,7 +104,7 @@ func (c *HCPConnectCommand) setupClients() error {
 
 		if c.flagClientID != "" && c.flagSecretID == "" {
 			return errors.New("secret-id is required when client-id is provided")
-		} else if c.flagSecretID != ""  && c.flagClientID == "" {
+		} else if c.flagSecretID != "" && c.flagClientID == "" {
 			return errors.New("client-id is required when secret-id is provided")
 		} else if c.flagClientID != "" && c.flagSecretID != "" {
 			opts = append(opts, config.WithClientCredentials(c.flagClientID, c.flagSecretID))

--- a/connect.go
+++ b/connect.go
@@ -101,7 +101,12 @@ func (c *HCPConnectCommand) setupClients() error {
 
 	if c.rmOrgClient == nil && c.rmProjClient == nil && c.vsClient == nil {
 		opts = []config.HCPConfigOption{config.FromEnv()}
-		if c.flagClientID != "" && c.flagSecretID != "" {
+
+		if c.flagClientID != "" && c.flagSecretID == "" {
+			return errors.New("secret-id is required when client-id is provided")
+		} else if c.flagSecretID != ""  && c.flagClientID == "" {
+			return errors.New("client-id is required when secret-id is provided")
+		} else if c.flagClientID != "" && c.flagSecretID != "" {
 			opts = append(opts, config.WithClientCredentials(c.flagClientID, c.flagSecretID))
 			opts = append(opts, config.WithoutBrowserLogin())
 		}

--- a/connect_test.go
+++ b/connect_test.go
@@ -37,21 +37,21 @@ func Test_HCPConnect_FlagValidation(t *testing.T) {
 		error string
 	}{
 		{
-			name: "invalid flags",
+			name:  "invalid flags",
 			flags: []string{"-invalid", "abc123"},
-			code: 1,
+			code:  1,
 			error: "flag provided but not defined: -invalid",
 		},
 		{
-			name: "only client-id provided",
+			name:  "only client-id provided",
 			flags: []string{"-client-id", "abc123"},
-			code: 1,
+			code:  1,
 			error: "secret-id is required when client-id is provided",
 		},
 		{
-			name: "only secret-id provided",
+			name:  "only secret-id provided",
 			flags: []string{"-secret-id", "abc123"},
-			code: 1,
+			code:  1,
 			error: "client-id is required when secret-id is provided",
 		},
 	}
@@ -258,7 +258,6 @@ func Test_getOrganization(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_getProject(t *testing.T) {
@@ -379,7 +378,6 @@ func Test_getProject(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_getCluster(t *testing.T) {

--- a/connect_test.go
+++ b/connect_test.go
@@ -29,6 +29,52 @@ func testHCPConnectCommand() (*cli.MockUi, *HCPConnectCommand) {
 	return ui, &HCPConnectCommand{Ui: ui}
 }
 
+func Test_HCPConnect_FlagValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		flags []string
+		code  int
+		error string
+	}{
+		{
+			name: "invalid flags",
+			flags: []string{"-invalid", "abc123"},
+			code: 1,
+			error: "flag provided but not defined: -invalid",
+		},
+		{
+			name: "only client-id provided",
+			flags: []string{"-client-id", "abc123"},
+			code: 1,
+			error: "secret-id is required when client-id is provided",
+		},
+		{
+			name: "only secret-id provided",
+			flags: []string{"-secret-id", "abc123"},
+			code: 1,
+			error: "client-id is required when secret-id is provided",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ui, cmd := testHCPConnectCommand()
+			result := cmd.Run(tc.flags)
+			output := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			assert.Equal(t, tc.code, result)
+
+			if tc.error != "" {
+				assert.Contains(t, output, tc.error)
+			}
+		})
+	}
+}
+
 func Test_HCPConnectCommand(t *testing.T) {
 	_, cmd := testHCPConnectCommand()
 

--- a/disconnect.go
+++ b/disconnect.go
@@ -12,9 +12,7 @@ import (
 	"github.com/hashicorp/cli"
 )
 
-var (
-	_ cli.Command = (*HCPDisconnectCommand)(nil)
-)
+var _ cli.Command = (*HCPDisconnectCommand)(nil)
 
 type HCPDisconnectCommand struct {
 	Ui cli.Ui

--- a/testhelpers.go
+++ b/testhelpers.go
@@ -4,8 +4,9 @@
 package vaulthcplib
 
 import (
-	"golang.org/x/oauth2"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 type TestTokenSource struct{}


### PR DESCRIPTION
# Overview
The non-interactive mode requires the user to provide both the -client-id and -secret-id flags. The user is provided with the same interactive mode message if they have only provided one of the required flags:

```
The default web browser has been opened at https://auth.idp.hashicorp.com/oauth2/auth. Please continue the login in the web browser.
```

This PR introduces validation so that an error is provided in non-interactive mode if either the `-client-id` or `-secret-id` flags are missing.

# Related Issues/Pull Requests
This will be incorporated with a Vault PR once approved and merged
