### PR TITLE
add error handling for creating and locked clusters

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -336,13 +336,17 @@ func (c *HCPConnectCommand) listClusters(organizationID string, projectID string
 
 	default:
 		cluster := clustersResp.GetPayload().Clusters[0]
-		if *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKED || *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKING {
+
+		clusterState := *cluster.State
+
+		if clusterState == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKED || clusterState == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKING {
 			return "", errors.New("cluster is locked")
-		} else if *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING {
+		} else if clusterState == hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING {
 			return "", errors.New("cluster is still being created")
-		} else if *cluster.State != hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING {
+		} else if clusterState != hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING {
 			return "", errors.New("cluster is not running")
 		}
+
 		if *cluster.Config.NetworkConfig.HTTPProxyOption == hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionDISABLED {
 			return "", ErrorProxyDisabled
 		}

--- a/connect.go
+++ b/connect.go
@@ -336,7 +336,11 @@ func (c *HCPConnectCommand) listClusters(organizationID string, projectID string
 
 	default:
 		cluster := clustersResp.GetPayload().Clusters[0]
-		if *cluster.State != hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING {
+		if *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKED || *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKING {
+			return "", errors.New("cluster is locked")
+		} else if *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING {
+			return "", errors.New("cluster is still being created")
+		} else if *cluster.State != hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING {
 			return "", errors.New("cluster is not running")
 		}
 		if *cluster.Config.NetworkConfig.HTTPProxyOption == hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionDISABLED {

--- a/connect_test.go
+++ b/connect_test.go
@@ -476,6 +476,105 @@ func Test_getCluster(t *testing.T) {
 			expectedError: errors.New("invalid cluster: cluster-4"),
 		},
 
+		// Test error handling for cluster still being created
+		// UI interaction required
+		"cluster in creating": {
+			userInputCluster: "cluster-2",
+			listClustersServiceListResponse: &hcpvs.ListOK{
+				Payload: &hcpvsm.HashicorpCloudVault20201125ListResponse{
+					Clusters: []*hcpvsm.HashicorpCloudVault20201125Cluster{
+						{
+							ID:       "cluster-1",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-1.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+						{
+							ID:       "cluster-2",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-2.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("cluster is still being created"),
+		},
+
+		// Test error handling for cluster is locked
+		// UI interaction required
+		"cluster locked": {
+			userInputCluster: "cluster-2",
+			listClustersServiceListResponse: &hcpvs.ListOK{
+				Payload: &hcpvsm.HashicorpCloudVault20201125ListResponse{
+					Clusters: []*hcpvsm.HashicorpCloudVault20201125Cluster{
+						{
+							ID:       "cluster-1",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-1.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKED),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+						{
+							ID:       "cluster-2",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-2.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("cluster is locked"),
+		},
+
+		// Test error handling for cluster is locked
+		// UI interaction required
+		"cluster locking": {
+			userInputCluster: "cluster-2",
+			listClustersServiceListResponse: &hcpvs.ListOK{
+				Payload: &hcpvsm.HashicorpCloudVault20201125ListResponse{
+					Clusters: []*hcpvsm.HashicorpCloudVault20201125Cluster{
+						{
+							ID:       "cluster-1",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-1.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateLOCKING),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+						{
+							ID:       "cluster-2",
+							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-2.addr:8200"},
+							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateCREATING),
+							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{
+								NetworkConfig: &hcpvsm.HashicorpCloudVault20201125NetworkConfig{
+									HTTPProxyOption: hcpvsm.NewHashicorpCloudVault20201125HTTPProxyOption(hcpvsm.HashicorpCloudVault20201125HTTPProxyOptionENABLED),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("cluster is locked"),
+		},
+
 		// Test generic expectedError returned
 		"expectedError": {
 			expectedError: errors.New("error getting cluster"),


### PR DESCRIPTION
# Overview
The options provided in the Choose a cluster prompt are not filtered and thus a user may be provided options where the clusters are still being created or are API locked. A user will be presented with an error `cluster is not running` if they choose a cluster in any state other than running.

This PR introduces error handling for the `CREATING`, `LOCKING`, and `LOCKED` cluster states.

# Related Issues/Pull Requests
This will be incorporated with a Vault PR once approved and merged
