### PR TITLE
Allow for path configuration on token helpers

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -19,6 +19,7 @@ import (
 	hcpvsm "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 	"github.com/hashicorp/hcp-sdk-go/config"
 	"github.com/hashicorp/hcp-sdk-go/httpclient"
+	"github.com/mitchellh/go-homedir"
 )
 
 var (
@@ -89,7 +90,13 @@ func (c *HCPConnectCommand) Run(args []string) int {
 		return 1
 	}
 
-	err = writeConfig(proxyAddr, c.flagClientID, c.flagSecretID)
+	path, err := homedir.Dir()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("\nFailed to find home directory: %s", err))
+		return 1
+	}
+
+	err = writeConfig(proxyAddr, c.flagClientID, c.flagSecretID, path)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("\nFailed to connect to HCP Vault Cluster: %s", err))
 		return 1

--- a/disconnect.go
+++ b/disconnect.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/config"
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/hashicorp/cli"
 )
@@ -30,8 +31,13 @@ Usage: vault hcp disconnect [options]
 }
 
 func (c *HCPDisconnectCommand) Run(_ []string) int {
-	err := eraseConfig()
+	path, err := homedir.Dir()
 	if err != nil {
+		c.Ui.Error(fmt.Sprintf("\nFailed to find home directory: %s", err))
+		return 1
+	}
+
+	if err := eraseConfig(path); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to disconnect from HCP Vault Cluster: %s", err))
 		return 1
 	}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
This is a follow up PR for #36 to refactor the code a little bit more to make it more testable. I've added a path configurable and a test to ensure we error out if the client supplies an empty path. If this is merged I will update the Vault CLI code to pass in a path (or ignore it).