### PR TITLE
VAULT-28317: Fix issue with lowercasing of HCP resources

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -242,8 +242,7 @@ func (c *HCPConnectCommand) getOrganization() (organizationID string, err error)
 		for _, org := range organizationsResp.GetPayload().Organizations {
 			if *org.State == hcprmm.HashicorpCloudResourcemanagerOrganizationOrganizationStateACTIVE {
 				c.Ui.Info(fmt.Sprintf("Organization name: %s", org.Name))
-				name := strings.ToLower(org.Name)
-				orgs[name] = org
+				orgs[org.Name] = org
 			}
 		}
 		userInput, err := c.Ui.Ask(fmt.Sprintf("\nChoose a organization: "))
@@ -288,8 +287,7 @@ func (c *HCPConnectCommand) getProject(organizationID string) (projectID string,
 		for _, proj := range projectResp.GetPayload().Projects {
 			if *proj.State == hcprmm.HashicorpCloudResourcemanagerProjectProjectStateACTIVE {
 				c.Ui.Info(fmt.Sprintf("Project name: %s", proj.Name))
-				name := strings.ToLower(proj.Name)
-				projs[name] = proj
+				projs[proj.Name] = proj
 			}
 		}
 		userInput, err := c.Ui.Ask(fmt.Sprintf("\nChoose a project: "))
@@ -366,8 +364,7 @@ func (c *HCPConnectCommand) listClusters(organizationID string, projectID string
 		for _, cluster := range clustersResp.GetPayload().Clusters {
 			if *cluster.State == hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING {
 				c.Ui.Info(fmt.Sprintf("Cluster identification: %s", cluster.ID))
-				id := strings.ToLower(cluster.ID)
-				clusters[id] = cluster
+				clusters[cluster.ID] = cluster
 			}
 		}
 		userInput, err := c.Ui.Ask("\nChoose a cluster:")

--- a/connect_test.go
+++ b/connect_test.go
@@ -179,7 +179,7 @@ func Test_HCPConnectCommand(t *testing.T) {
 							Projects: []*models.HashicorpCloudResourcemanagerProject{
 								{
 									ID:   uuid.New().String(),
-									Name: "mock-project-1",
+									Name: "Mock-project-1",
 									State: models.NewHashicorpCloudResourcemanagerProjectProjectState(
 										models.HashicorpCloudResourcemanagerProjectProjectStateACTIVE,
 									),
@@ -260,7 +260,7 @@ func Test_getOrganization(t *testing.T) {
 		// Test multiple organizations
 		// UI interaction required
 		"multiple organizations": {
-			userInputOrganizationName: "mock-organization-2\n",
+			userInputOrganizationName: "MOCK-organization-2\n",
 			expectedOrganizationID:    organizationIDTwo,
 			organizationServiceListResponse: &hcprmo.OrganizationServiceListOK{
 				Payload: &models.HashicorpCloudResourcemanagerOrganizationListResponse{
@@ -272,7 +272,7 @@ func Test_getOrganization(t *testing.T) {
 						},
 						{
 							ID:    organizationIDTwo,
-							Name:  "mock-organization-2",
+							Name:  "MOCK-organization-2",
 							State: models.NewHashicorpCloudResourcemanagerOrganizationOrganizationState(models.HashicorpCloudResourcemanagerOrganizationOrganizationStateACTIVE),
 						},
 						{
@@ -382,7 +382,7 @@ func Test_getProject(t *testing.T) {
 		// Test multiple projects
 		// UI interaction required
 		"multiple projects": {
-			userInputProjectName: "mock-project-2\n",
+			userInputProjectName: "MOCK_-project-2\n",
 			expectedProjectID:    projectIDTwo,
 			projectServiceListResponse: &hcprmp.ProjectServiceListOK{
 				Payload: &models.HashicorpCloudResourcemanagerProjectListResponse{
@@ -394,7 +394,7 @@ func Test_getProject(t *testing.T) {
 						},
 						{
 							ID:    projectIDTwo,
-							Name:  "mock-project-2",
+							Name:  "MOCK_-project-2",
 							State: models.NewHashicorpCloudResourcemanagerProjectProjectState(models.HashicorpCloudResourcemanagerProjectProjectStateACTIVE),
 						},
 						{
@@ -529,7 +529,7 @@ func Test_getCluster(t *testing.T) {
 		// UI interaction required
 		"multiple clusters": {
 			expectedProxyAddr: "https://hcp-proxy-cluster-2.addr:8200",
-			userInputCluster:  "cluster-2\n",
+			userInputCluster:  "CLUSTER-2\n",
 			listClustersServiceListResponse: &hcpvs.ListOK{
 				Payload: &hcpvsm.HashicorpCloudVault20201125ListResponse{
 					Clusters: []*hcpvsm.HashicorpCloudVault20201125Cluster{
@@ -544,7 +544,7 @@ func Test_getCluster(t *testing.T) {
 							},
 						},
 						{
-							ID:       "cluster-2",
+							ID:       "CLUSTER-2",
 							DNSNames: &hcpvsm.HashicorpCloudVault20201125ClusterDNSNames{Proxy: "hcp-proxy-cluster-2.addr:8200"},
 							State:    hcpvsm.NewHashicorpCloudVault20201125ClusterState(hcpvsm.HashicorpCloudVault20201125ClusterStateRUNNING),
 							Config: &hcpvsm.HashicorpCloudVault20201125ClusterConfig{


### PR DESCRIPTION
# Overview

This fixes an issue where the names of HCP resources would be lowercased. Since HCP resources are case sensitive, this means that if you have e.g. "foo" and "FOO", you would be unable to access one of them.

Likewise, if you had a project called "FOO", you could previously only access it via typing "foo", which was a pain point forsome users.

This could affect a customer that was previously accessing "FOO" by typing "foo", but ultimately that's on them, since these resources are case sensitive.

I tested this in Vault to fix issues found in `vault hcp connect` using the following:
`replace github.com/hashicorp/vault-hcp-lib => ../vault-hcp-lib`

Once merged, I'll update this in Vault, and backport it etc.

# Contributor Checklist
- [Will be added after] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [N/A] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [It has a minor incompatibility if the user was writing the name of their uppercase project in lowercase but fixes a bug] Backwards compatible
