### PR TITLE
Change codeowner from vault-core-hybrid to vault-core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@
 #
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @hashicorp/vault-core-hybrid
+* @hashicorp/vault-core
 


### PR DESCRIPTION
I'd like to decommission the vault-core-hybrid GitHub team and expand the codeowners group here to be slightly larger.

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change?
Why is the change needed?
How does this change affect the user experience (if at all)?

# Related Issues/Pull Requests
- [ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
- [ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible

# PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
